### PR TITLE
[Bug]: RevisionsPage showVersion accepts int only; breaks with UUID

### DIFF
--- a/resources/views/revisions-page.blade.php
+++ b/resources/views/revisions-page.blade.php
@@ -74,7 +74,7 @@
                     >
                         @foreach ($this->revisionsList as $version)
                             <li
-                                wire:click="showVersion({{ $version->id }})"
+                                wire:click="showVersion('{{ $version->id }}')"
                                 @class([
                                     'pb-4' => $loop->first && !$loop->last,
                                     'pt-4' => $loop->last && !$loop->first,

--- a/resources/views/revisions-page.blade.php
+++ b/resources/views/revisions-page.blade.php
@@ -74,7 +74,7 @@
                     >
                         @foreach ($this->revisionsList as $version)
                             <li
-                                wire:click="showVersion('{{ $version->id }}')"
+                                wire:click="showVersion(@js($version->getKey()))"
                                 @class([
                                     'pb-4' => $loop->first && !$loop->last,
                                     'pt-4' => $loop->last && !$loop->first,

--- a/src/RevisionsPage.php
+++ b/src/RevisionsPage.php
@@ -75,7 +75,7 @@ class RevisionsPage extends Page
             ->paginate($this->getRevisionsListPerPage());
     }
 
-    public function showVersion(int $versionId): void
+    public function showVersion(int|string $versionId): void
     {
         $this->version = $this->record->getVersion($versionId);
     }


### PR DESCRIPTION
## Description

Fixes a bug in the `RevisionsPage` component where the `showVersion` method fails when passing a UUID version ID from the frontend.

### Problem

When version IDs are UUIDs (e.g., `2677d84b-0f60-4d26-8132-7e926e1da4ba`), using:

```blade
@click="$wire.showVersion({{ $version->id }})"
```

throws a syntax error in the browser:
_Alpine Expression Error: Invalid or unexpected token_